### PR TITLE
Deserialize manifest resources from stream

### DIFF
--- a/src/Bicep.Types.K8s.UnitTests/packages.lock.json
+++ b/src/Bicep.Types.K8s.UnitTests/packages.lock.json
@@ -197,7 +197,7 @@
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "10.0.3",
-        "contentHash": "wBM7i7i3U2WX0ecor4zdVGvgrwFUjuigBoHKiL+nH39fCOpCPjBY3RDqJM32edvdyTAVdjzlccHsg41+/+zpSA==",
+        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
@@ -369,7 +369,7 @@
       "System.Collections.NonGeneric": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "m7pXubhUhtS7ON/QkuAb4SauHBP1ZvGhvSkmRclvpIIBj1E4hvAryP/hTURFTMzWTCV4fz3/7N6gJpDHF6ZmdQ==",
+        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -382,7 +382,7 @@
       "System.Collections.Specialized": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "XDVjHrZFKcFrKEF02DejanefEbrD+0BA4VANickE08z737/5W3mvPL8WfuAORRdFusoFgtAEHN8NfrIzwkPl9w==",
+        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
         "dependencies": {
           "System.Collections.NonGeneric": "4.3.0",
           "System.Globalization": "4.3.0",

--- a/src/Bicep.Types.K8s.UnitTests/packages.lock.json
+++ b/src/Bicep.Types.K8s.UnitTests/packages.lock.json
@@ -61,10 +61,10 @@
       },
       "Azure.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.2.8",
-        "contentHash": "l1DZerBJE71hKZRJRXCmvOFLJYb96+2PWSV28bgDJgzmfF6TWh9rOLOgpd2XsHsqSinjE+95IFE//5KAZhWc8g==",
+        "resolved": "0.3.4",
+        "contentHash": "B+jpNssdLB6qDLmw0WhgsgziEnQZ1TB1tpDrJ69802jQdY3v0YRH0edE3/9QLtXBDHezD/Pbrh66deailLEN5Q==",
         "dependencies": {
-          "System.Text.Json": "6.0.5"
+          "System.Text.Json": "6.0.6"
         }
       },
       "Microsoft.Build.Tasks.Git": {
@@ -197,7 +197,7 @@
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "10.0.3",
-        "contentHash": "hSXaFmh7hNCuEoC4XNY5DrRkLDzYHqPx/Ik23R4J86Z7PE/Y6YidhG602dFVdLBRSdG6xp9NabH3dXpcoxWvww==",
+        "contentHash": "wBM7i7i3U2WX0ecor4zdVGvgrwFUjuigBoHKiL+nH39fCOpCPjBY3RDqJM32edvdyTAVdjzlccHsg41+/+zpSA==",
         "dependencies": {
           "Microsoft.CSharp": "4.3.0",
           "NETStandard.Library": "1.6.1",
@@ -369,7 +369,7 @@
       "System.Collections.NonGeneric": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+        "contentHash": "m7pXubhUhtS7ON/QkuAb4SauHBP1ZvGhvSkmRclvpIIBj1E4hvAryP/hTURFTMzWTCV4fz3/7N6gJpDHF6ZmdQ==",
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -382,7 +382,7 @@
       "System.Collections.Specialized": {
         "type": "Transitive",
         "resolved": "4.3.0",
-        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
+        "contentHash": "XDVjHrZFKcFrKEF02DejanefEbrD+0BA4VANickE08z737/5W3mvPL8WfuAORRdFusoFgtAEHN8NfrIzwkPl9w==",
         "dependencies": {
           "System.Collections.NonGeneric": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -1122,8 +1122,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "SSH+YYrMpvLcy7Orzb5K1tSyffnFacWahyxCCjYH1PbSHdAF4dekmIetBurFKgtTHDmwEe/J2Csi/7niRH6d/g==",
+        "resolved": "6.0.6",
+        "contentHash": "GZ+62pLOr544jwSvyXv5ezSfzlFBTjLuPhgOS2dnKuknAA8dPNUGXLKTHf9XdsudU9JpbtweXnE4oEiKEB2T1Q==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"
@@ -1237,7 +1237,7 @@
       "Azure.Bicep.Types.K8s": {
         "type": "Project",
         "dependencies": {
-          "Azure.Bicep.Types": "[0.2.8, )"
+          "Azure.Bicep.Types": "[0.3.4, )"
         }
       }
     }

--- a/src/Bicep.Types.K8s/Bicep.Types.K8s.csproj
+++ b/src/Bicep.Types.K8s/Bicep.Types.K8s.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Bicep.Types" Version="0.2.8" />
+    <PackageReference Include="Azure.Bicep.Types" Version="0.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Types.K8s/Index/TypeIndexer.cs
+++ b/src/Bicep.Types.K8s/Index/TypeIndexer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -15,6 +16,11 @@ namespace Azure.Bicep.Types.K8s.Index
         public static TypeIndex DeserializeIndex(string content)
         {
             return JsonSerializer.Deserialize<TypeIndex>(content, SerializeOptions) ?? throw new JsonException("Failed to deserialize index");
+        }
+
+        public static TypeIndex DeserializeIndex(Stream contentStream)
+        {
+            return JsonSerializer.Deserialize<TypeIndex>(contentStream, SerializeOptions) ?? throw new JsonException("Failed to deserialize index");
         }
     }
 }

--- a/src/Bicep.Types.K8s/packages.lock.json
+++ b/src/Bicep.Types.K8s/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETStandard,Version=v2.0": {
       "Azure.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.2.8, )",
-        "resolved": "0.2.8",
-        "contentHash": "l1DZerBJE71hKZRJRXCmvOFLJYb96+2PWSV28bgDJgzmfF6TWh9rOLOgpd2XsHsqSinjE+95IFE//5KAZhWc8g==",
+        "requested": "[0.3.4, )",
+        "resolved": "0.3.4",
+        "contentHash": "B+jpNssdLB6qDLmw0WhgsgziEnQZ1TB1tpDrJ69802jQdY3v0YRH0edE3/9QLtXBDHezD/Pbrh66deailLEN5Q==",
         "dependencies": {
-          "System.Text.Json": "6.0.5"
+          "System.Text.Json": "6.0.6"
         }
       },
       "Microsoft.SourceLink.GitHub": {
@@ -96,8 +96,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "SSH+YYrMpvLcy7Orzb5K1tSyffnFacWahyxCCjYH1PbSHdAF4dekmIetBurFKgtTHDmwEe/J2Csi/7niRH6d/g==",
+        "resolved": "6.0.6",
+        "contentHash": "GZ+62pLOr544jwSvyXv5ezSfzlFBTjLuPhgOS2dnKuknAA8dPNUGXLKTHf9XdsudU9JpbtweXnE4oEiKEB2T1Q==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "System.Buffers": "4.5.1",


### PR DESCRIPTION
Currently to deserialize a manifest resource we are deflating the resource stream via a StreamReader to a string and then deserializing that string. Instead we can directly deserialize from the deflate stream without a string allocation. This upgrades to 0.3.4 of Azure.Bicep.Types so TypeSerializer can be called with a stream via https://github.com/Azure/bicep-types/pull/7
Identical change to Azure/bicep-types-az#1124