### PR TITLE
Fix types.json path

### DIFF
--- a/generated/v1.29.0/index.json
+++ b/generated/v1.29.0/index.json
@@ -203,7 +203,7 @@
     "isPreview": true,
     "version": "1.29.0",
     "configurationType": {
-      "$ref": "type.json#/2"
+      "$ref": "types.json#/2"
     }
   }
 }

--- a/generated/v1.30.0/index.json
+++ b/generated/v1.30.0/index.json
@@ -221,7 +221,7 @@
     "isPreview": true,
     "version": "1.30.0",
     "configurationType": {
-      "$ref": "type.json#/2"
+      "$ref": "types.json#/2"
     }
   }
 }

--- a/generated/v1.31.0/index.json
+++ b/generated/v1.31.0/index.json
@@ -221,7 +221,7 @@
     "isPreview": true,
     "version": "1.31.0",
     "configurationType": {
-      "$ref": "type.json#/2"
+      "$ref": "types.json#/2"
     }
   }
 }

--- a/generated/v1.32.0/index.json
+++ b/generated/v1.32.0/index.json
@@ -224,7 +224,7 @@
     "isPreview": true,
     "version": "1.32.0",
     "configurationType": {
-      "$ref": "type.json#/2"
+      "$ref": "types.json#/2"
     }
   }
 }

--- a/generated/v1.33.0/index.json
+++ b/generated/v1.33.0/index.json
@@ -251,7 +251,7 @@
     "isPreview": true,
     "version": "1.33.0",
     "configurationType": {
-      "$ref": "type.json#/2"
+      "$ref": "types.json#/2"
     }
   }
 }

--- a/src/generator/src/type-index.ts
+++ b/src/generator/src/type-index.ts
@@ -49,7 +49,7 @@ async function buildTypeIndex(tag: string, logger: Logger) {
   const settings = {
     ...baseSettings,
     version: tag.slice(1), // v1.0.0 => 1.0.0
-    configurationType: new CrossFileTypeReference("type.json", configurationType.index),
+    configurationType: new CrossFileTypeReference("types.json", configurationType.index),
   };
 
   const index = buildIndex(typeFiles, log => logger.info(log), settings);


### PR DESCRIPTION
Found an error in `index.json` when testing extension publishing pipeline in ADO.